### PR TITLE
Updated pcre Version

### DIFF
--- a/app.sh
+++ b/app.sh
@@ -3,7 +3,7 @@ LDFLAGS="-L${DEST}/lib -L${DEPS}/lib -Wl,--gc-sections"
 
 ### PCRE ###
 _build_pcre() {
-local VERSION="8.37"
+local VERSION="8.39"
 local FOLDER="pcre-${VERSION}"
 local FILE="${FOLDER}.tar.bz2"
 local URL="ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/${FILE}"


### PR DESCRIPTION
Busybox doesn't build with the old requirement. I updated the library version and it now builds correctly.