### PR TITLE
updating pcre to current available version

### DIFF
--- a/app.sh
+++ b/app.sh
@@ -3,7 +3,7 @@ LDFLAGS="-L${DEST}/lib -L${DEPS}/lib -Wl,--gc-sections"
 
 ### PCRE ###
 _build_pcre() {
-local VERSION="8.37"
+local VERSION="8.41"
 local FOLDER="pcre-${VERSION}"
 local FILE="${FOLDER}.tar.bz2"
 local URL="ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/${FILE}"


### PR DESCRIPTION
There is another outstanding pull request by economysizegeek that includes a version that is now also out of date. Not sure why older versions are not left available for download but perhaps a query could be made against available versions to mitigate this needing to be updated constantly.